### PR TITLE
fix log file destination

### DIFF
--- a/Sources/DebounceMac/logger.swift
+++ b/Sources/DebounceMac/logger.swift
@@ -14,7 +14,7 @@ func setupLogger() -> SwiftyBeaver.Type {
     }()
     let fileDestination: FileDestination = {
         let file = FileDestination()
-        file.logFileURL = URL(fileURLWithPath: "/Users/NobuhiroUeda/Library/Caches/debounce_mac.log")  // default: ~/Library/Caches/swiftybeaver.log
+        file.logFileURL = URL(fileURLWithPath: "\(NSHomeDirectory())/Library/Caches/debounce_mac.log")  // default: ~/Library/Caches/swiftybeaver.log
         file.format = "$Dyyyy-MM-dd HH:mm:ss.SSS$d $C$L$c $N.$F:$l - $M"  // 2019-08-04 19:42:51.612 INFO main.tapEvents():54 - Initializing an event tap.
         file.minLevel = .info  // default: .verbose
         return file


### PR DESCRIPTION
I found the log file path is hard coded and no logs are printed.

```
SwiftyBeaver File Destination could not write to file file:///Users/NobuhiroUeda/Library/Caches/debounce_mac.log.
```

This PR will fix the issue.

btw thank you very much, this tool likely resolved my keyboard trouble ...!!!