### PR TITLE
Stop writing key codes and characters to the log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ swift build -c release
 
 Note: to build this program, you need Xcode installed.
 
+## Privacy
+
+DebounceMac inspects every keystroke to do its job, but it does not record what
+you type: key codes and characters are never written to the console or to the
+log file (`~/Library/Caches/debounce_mac.log`) — the log contains operational
+events only. Versions up to v0.2.1 wrote the key code of every keypress to that
+log file; if you ran one of them, delete the old file:
+
+```shell
+rm ~/Library/Caches/debounce_mac.log
+```
+
 ## Auto-start at login
 
 ```shell

--- a/Sources/DebounceMac/config.swift
+++ b/Sources/DebounceMac/config.swift
@@ -98,7 +98,8 @@ class Config {
     }
 
     func getDelay(keyCode: CGKeyCode, modifierFlags: NSEvent.ModifierFlags) -> Int? {
-        logger.debug("key code: \(keyCode) modifiers: \(modifierMap.filter { modifierFlags.contains($0.value) }.keys)")
+        // Key codes are typed content; .verbose keeps them out of every default destination.
+        logger.verbose("key code: \(keyCode) modifiers: \(modifierMap.filter { modifierFlags.contains($0.value) }.keys)")
         if let conditionalDelay = delayDict[keyCode] {
             logger.debug("condition: \(conditionalDelay)")
             var resultDelay: Int?

--- a/Sources/DebounceMac/logger.swift
+++ b/Sources/DebounceMac/logger.swift
@@ -4,6 +4,10 @@ import SwiftyBeaver
 func setupLogger() -> SwiftyBeaver.Type {
     let logger = SwiftyBeaver.self
 
+    // Privacy invariant: key codes and characters are logged at .verbose only.
+    // Neither destination below may have minLevel lower than .debug, otherwise
+    // typed content would reach the console or the persistent log file.
+
     let consoleDestination: ConsoleDestination = {
         let console = ConsoleDestination()
         console.format = "$Dyyyy-MM-dd HH:mm:ss$d $C$L$c: $M" // 2019-08-04 19:42:51 INFO: Initializing an event tap.

--- a/Sources/DebounceMac/main.swift
+++ b/Sources/DebounceMac/main.swift
@@ -92,15 +92,17 @@ class KeyChanger {
             let currentKeyTime = Int64(Date().timeIntervalSince1970 * 1000)
             let currentKeyCode = nsEvent.keyCode
             let keyboardId = cgEvent.getIntegerValueField(.keyboardEventKeyboardType)
-            // debug logging
-            logger.info("keyboardId: \(keyboardId)")
-            logger.info("currentKeyCode: \(currentKeyCode)")
+            // Key codes reconstruct everything the user types, so they are logged
+            // only at .verbose, a level no default destination emits or persists.
+            logger.verbose("keyboardId: \(keyboardId)")
+            logger.verbose("currentKeyCode: \(currentKeyCode)")
 
             if keyboardId != SYNTHETIC_KB_ID && currentKeyCode == lastKeyCode && !(nsEvent.isARepeat) {
                 if let debounceDelay = config.getDelay(keyCode: currentKeyCode, modifierFlags: nsEvent.modifierFlags) {
                     logger.debug("delay: \(debounceDelay) ? \(currentKeyTime) - \(lastKeyTime)")
                     if (currentKeyTime - lastKeyTime) < debounceDelay {
-                        logger.info("BOUNCE detected!!!  Character: '" + (nsEvent.characters ?? "") + "'")
+                        logger.info("BOUNCE detected!!!")
+                        logger.verbose("bounced keyCode: \(currentKeyCode)")
                         logger.info("Time between keys: \(currentKeyTime - lastKeyTime)ms (< \(debounceDelay)ms)")
 
                         lastKeyTime = currentKeyTime


### PR DESCRIPTION
Every keyDown currently logs its key code (and, on bounce, the literal character) at `.info`, which the file destination persists to `~/Library/Caches/debounce_mac.log`. Since key codes map 1:1 to keys, that file amounts to a plaintext record of everything typed — including passwords — readable by any process running as the user, with no rotation.

This PR moves all typed-content logging to `.verbose`, which neither default destination emits, so the log file keeps only operational events (tap lifecycle, bounce occurrences, timing):

- `main.swift`: per-event `keyboardId`/`currentKeyCode` lines and the bounced-character line move from `.info` to `.verbose`; bounce events are still logged at `.info` as occurrence + timing, just without the typed content.
- `config.swift`: per-lookup key-code line moves from `.debug` to `.verbose`.
- `logger.swift`: comment documenting the invariant (typed content only at `.verbose`; destinations must not go below `.debug`).
- `README.md`: privacy section, including a note for users of earlier versions to delete the old log file.

Debugging is unchanged apart from one local tweak: set `console.minLevel = .verbose` in `logger.swift` to see per-event key codes again.

No functional change to debouncing. `swift build` passes.
